### PR TITLE
GH-20 Create the camera "look at" path functionality

### DIFF
--- a/Assets/Rendering/PostProcessingProfile.asset
+++ b/Assets/Rendering/PostProcessingProfile.asset
@@ -12,7 +12,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 0b2db86121404754db890f4c8dfe81b2, type: 3}
   m_Name: Bloom
   m_EditorClassIdentifier: 
-  active: 1
+  active: 0
+  skipIterations:
+    m_OverrideState: 1
+    m_Value: 1
   threshold:
     m_OverrideState: 1
     m_Value: 0.9
@@ -31,12 +34,16 @@ MonoBehaviour:
   highQualityFiltering:
     m_OverrideState: 1
     m_Value: 0
-  skipIterations:
-    m_OverrideState: 1
-    m_Value: 1
+  downscale:
+    m_OverrideState: 0
+    m_Value: 0
+  maxIterations:
+    m_OverrideState: 0
+    m_Value: 6
   dirtTexture:
     m_OverrideState: 1
     m_Value: {fileID: 0}
+    dimension: 1
   dirtIntensity:
     m_OverrideState: 1
     m_Value: 0
@@ -102,6 +109,30 @@ MonoBehaviour:
   mode:
     m_OverrideState: 1
     m_Value: 2
+  neutralHDRRangeReductionMode:
+    m_OverrideState: 0
+    m_Value: 2
+  acesPreset:
+    m_OverrideState: 0
+    m_Value: 3
+  hueShiftAmount:
+    m_OverrideState: 0
+    m_Value: 0
+  detectPaperWhite:
+    m_OverrideState: 0
+    m_Value: 0
+  paperWhite:
+    m_OverrideState: 0
+    m_Value: 300
+  detectBrightnessLimits:
+    m_OverrideState: 0
+    m_Value: 1
+  minNits:
+    m_OverrideState: 0
+    m_Value: 0.005
+  maxNits:
+    m_OverrideState: 0
+    m_Value: 1000
 --- !u!114 &2950893884365311496
 MonoBehaviour:
   m_ObjectHideFlags: 3

--- a/Assets/Scenes/MainScene.unity
+++ b/Assets/Scenes/MainScene.unity
@@ -1094,7 +1094,7 @@ MonoBehaviour:
   m_Path: {fileID: 2022913969}
   m_UpdateMethod: 0
   m_PositionUnits: 1
-  m_Speed: 2
+  m_Speed: 4
   m_Position: 0
 --- !u!4 &1526463678
 Transform:
@@ -1103,7 +1103,7 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1526463676}
-  m_LocalRotation: {x: 0, y: 0.37599814, z: 0, w: 0.9266204}
+  m_LocalRotation: {x: 0, y: 0.5235193, z: 0, w: 0.8520138}
   m_LocalPosition: {x: -28.407158, y: 0, z: -7.396449}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_ConstrainProportionsScale: 0
@@ -1478,7 +1478,19 @@ MonoBehaviour:
   m_Waypoints:
   - position: {x: -7.4897633, y: 0, z: -7.396449}
     roll: 0
-  - position: {x: 5.5195065, y: 0, z: 5.994349}
+  - position: {x: 7.6792183, y: 0, z: -1.9032621}
+    roll: 0
+  - position: {x: 19.045696, y: 0, z: -1.3813438}
+    roll: 0
+  - position: {x: 21.442429, y: 0, z: 12.859013}
+    roll: 0
+  - position: {x: 23.83916, y: 0, z: 27.09937}
+    roll: 0
+  - position: {x: 24.704298, y: 0, z: 65.646454}
+    roll: 0
+  - position: {x: -16.645067, y: 0, z: 102.55069}
+    roll: 0
+  - position: {x: -42.56324, y: 0, z: 33.334564}
     roll: 0
 --- !u!4 &2022913970
 Transform:
@@ -3334,6 +3346,11 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 814417836257332542, guid: 761cdc9e4e883334cbdcea062d0befa7,
         type: 3}
+      propertyPath: DollyCart
+      value: 
+      objectReference: {fileID: 1526463677}
+    - target: {fileID: 814417836257332542, guid: 761cdc9e4e883334cbdcea062d0befa7,
+        type: 3}
       propertyPath: gravityDownForce
       value: 20
       objectReference: {fileID: 0}
@@ -3989,7 +4006,7 @@ PrefabInstance:
     - target: {fileID: 2015434656898269656, guid: 25a1b0efadb966e44889fce712c8ff8d,
         type: 3}
       propertyPath: m_LocalPosition.x
-      value: 6.4999995
+      value: 1.56
       objectReference: {fileID: 0}
     - target: {fileID: 2015434656898269656, guid: 25a1b0efadb966e44889fce712c8ff8d,
         type: 3}
@@ -3999,12 +4016,12 @@ PrefabInstance:
     - target: {fileID: 2015434656898269656, guid: 25a1b0efadb966e44889fce712c8ff8d,
         type: 3}
       propertyPath: m_LocalPosition.z
-      value: 0
+      value: -39.84
       objectReference: {fileID: 0}
     - target: {fileID: 2015434656898269656, guid: 25a1b0efadb966e44889fce712c8ff8d,
         type: 3}
       propertyPath: m_LocalRotation.w
-      value: 1
+      value: -0.12888923
       objectReference: {fileID: 0}
     - target: {fileID: 2015434656898269656, guid: 25a1b0efadb966e44889fce712c8ff8d,
         type: 3}
@@ -4014,7 +4031,7 @@ PrefabInstance:
     - target: {fileID: 2015434656898269656, guid: 25a1b0efadb966e44889fce712c8ff8d,
         type: 3}
       propertyPath: m_LocalRotation.y
-      value: -0
+      value: -0.991659
       objectReference: {fileID: 0}
     - target: {fileID: 2015434656898269656, guid: 25a1b0efadb966e44889fce712c8ff8d,
         type: 3}
@@ -4029,7 +4046,7 @@ PrefabInstance:
     - target: {fileID: 2015434656898269656, guid: 25a1b0efadb966e44889fce712c8ff8d,
         type: 3}
       propertyPath: m_LocalEulerAnglesHint.y
-      value: 0
+      value: -194.811
       objectReference: {fileID: 0}
     - target: {fileID: 2015434656898269656, guid: 25a1b0efadb966e44889fce712c8ff8d,
         type: 3}

--- a/Assets/Scripts/Editor/fps.Editor.asmdef
+++ b/Assets/Scripts/Editor/fps.Editor.asmdef
@@ -1,10 +1,12 @@
 {
     "name": "fps.Editor",
+    "rootNamespace": "",
     "references": [
         "GUID:9c5543eabb73a6249ac07b2c065ee8b4",
         "GUID:27b7e9efd224f064990a97ed99e4456f",
         "GUID:e9dc24b3d0971d64a9e95b6986d97af5",
-        "GUID:269903ea973e2a64ca0fb91ee07d3625"
+        "GUID:269903ea973e2a64ca0fb91ee07d3625",
+        "GUID:33759803a11f4d538227861a78aba30b"
     ],
     "includePlatforms": [
         "Editor"

--- a/Assets/Scripts/Gameplay/fps.Gameplay.asmdef
+++ b/Assets/Scripts/Gameplay/fps.Gameplay.asmdef
@@ -1,7 +1,10 @@
 {
     "name": "fps.Gameplay",
+    "rootNamespace": "",
     "references": [
-        "GUID:9c5543eabb73a6249ac07b2c065ee8b4"
+        "GUID:9c5543eabb73a6249ac07b2c065ee8b4",
+        "GUID:4307f53044263cf4b835bd812fc161a4",
+        "GUID:33759803a11f4d538227861a78aba30b"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Scripts/UI/fps.UI.asmdef
+++ b/Assets/Scripts/UI/fps.UI.asmdef
@@ -1,10 +1,12 @@
 {
     "name": "fps.UI",
+    "rootNamespace": "",
     "references": [
         "GUID:9c5543eabb73a6249ac07b2c065ee8b4",
         "GUID:27b7e9efd224f064990a97ed99e4456f",
         "GUID:e9dc24b3d0971d64a9e95b6986d97af5",
-        "GUID:6055be8ebefd69e48b49212b09b47b2f"
+        "GUID:6055be8ebefd69e48b49212b09b47b2f",
+        "GUID:33759803a11f4d538227861a78aba30b"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],


### PR DESCRIPTION
Added "look at" functionality through Quaternion.Slerp to smooth PlayerCharacterController camera movement PlayerCharacterController now inherits from ValidatedMonobehaviour which allows us to have components from the same object inside "OnValidate" callback automatically and more performant with the help of the KBCore.Refs package. Added Reference to KBCore.Refs package reference to Gameplay, Editor and UI assemblies Added the function to make the camera to look always in the same direction of movement (based on a reference to the scene dolly cart) Added reference to cinemachine in fps.Gameplay assembly definition Autoupdated PostProcessing profile
Modified track path to be more extend across the level and changed velocity of movement to be 3
Resolves #20 