### PR TITLE
BFE-22 Restrict the aiming crosshair to move only inside the screen bounds

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -42,7 +42,6 @@ GameObject:
   - component: {fileID: 4161014806516094018}
   - component: {fileID: 7949365323635456102}
   - component: {fileID: 4597686015690357485}
-  - component: {fileID: 4232571076281731457}
   m_Layer: 0
   m_Name: DebugAimingSphere
   m_TagString: Untagged
@@ -58,12 +57,12 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 871641237462498283}
   serializedVersion: 2
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0.3}
-  m_LocalScale: {x: 0.2, y: 0.2, z: 0.2}
+  m_LocalRotation: {x: -0, y: 0.000000014901161, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 29.999971}
+  m_LocalScale: {x: 20, y: 20, z: 20}
   m_ConstrainProportionsScale: 1
   m_Children: []
-  m_Father: {fileID: 7890148077107935202}
+  m_Father: {fileID: 8490528891985581201}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!33 &7949365323635456102
 MeshFilter:
@@ -115,27 +114,6 @@ MeshRenderer:
   m_SortingLayer: 0
   m_SortingOrder: 0
   m_AdditionalVertexStreams: {fileID: 0}
---- !u!135 &4232571076281731457
-SphereCollider:
-  m_ObjectHideFlags: 0
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_GameObject: {fileID: 871641237462498283}
-  m_Material: {fileID: 0}
-  m_IncludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_ExcludeLayers:
-    serializedVersion: 2
-    m_Bits: 0
-  m_LayerOverridePriority: 0
-  m_IsTrigger: 0
-  m_ProvidesContacts: 0
-  m_Enabled: 1
-  serializedVersion: 3
-  m_Radius: 0.5
-  m_Center: {x: -0.0000019073486, y: 0, z: 8.526513e-14}
 --- !u!1 &1379779042212411169
 GameObject:
   m_ObjectHideFlags: 0
@@ -168,11 +146,12 @@ RectTransform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 550677980006962960}
+  - {fileID: 4161014806516094018}
   m_Father: {fileID: 7890148077107935202}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
   m_AnchorMax: {x: 0, y: 0}
-  m_AnchoredPosition: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0.2}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!223 &6722015181731078598
@@ -185,7 +164,7 @@ Canvas:
   m_Enabled: 1
   serializedVersion: 3
   m_RenderMode: 2
-  m_Camera: {fileID: 2286125971047457827}
+  m_Camera: {fileID: 8303093099919959869}
   m_PlaneDistance: 100
   m_PixelPerfect: 0
   m_ReceivesEvents: 1
@@ -195,8 +174,8 @@ Canvas:
   m_VertexColorAlwaysGammaSpace: 1
   m_AdditionalShaderChannelsFlag: 0
   m_UpdateRectTransformForStandalone: 0
-  m_SortingLayerID: 0
-  m_SortingOrder: 0
+  m_SortingLayerID: -372683831
+  m_SortingOrder: 1
   m_TargetDisplay: 0
 --- !u!114 &4541770050512722401
 MonoBehaviour:
@@ -300,7 +279,6 @@ Transform:
   m_ConstrainProportionsScale: 0
   m_Children:
   - {fileID: 8490528891985581201}
-  - {fileID: 4161014806516094018}
   m_Father: {fileID: 8746678193447392789}
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &891879066114389480

--- a/Assets/Scripts/Common/ExtensionMethods/TransformExtensionMethods.cs
+++ b/Assets/Scripts/Common/ExtensionMethods/TransformExtensionMethods.cs
@@ -4,23 +4,46 @@ public static class TransformExtensionMethods
 {
     public static void SmoothLookAt(this Transform objectToRotateToLookAt, Transform target, Vector3 up, float smoothSpeed)
     {
+        if (objectToRotateToLookAt == null || target == null) return; //we don't do anything if the object is null
         //we get the forward direction where we want to look at (direction vector resulting of the target minus the source object)
         Vector3 lookForwardDirection = (target.position - objectToRotateToLookAt.position).normalized;
         //we calculate the rotation to face the forward vector (the destination rotation)
         Quaternion targetLookRotation = Quaternion.LookRotation(lookForwardDirection, up);
         //we make an interpolation between our source object (objectToRotateToLookAt) and the lookRotation
         Quaternion smoothRotationToTarget = Quaternion.Lerp(objectToRotateToLookAt.rotation, targetLookRotation, Time.deltaTime * smoothSpeed);
-        //we asign our "partial" rotation
+        //we assign our "partial" rotation
         objectToRotateToLookAt.rotation = smoothRotationToTarget;
     }
 
     public static void SmoothTranslate(this Transform objectToTranslate, float verticalInput, float horizontalInput, Vector3 up, Vector3 right, float deltaTime)
     {
+        if (objectToTranslate == null) return; //we don't do anything if the object is null
         //we make our directions to point in the relative up directions
         Vector3 verticalRelativeInputMovement = verticalInput * up * deltaTime;
         //we make our directions to point in the relative right directions
         Vector3 horizontalRelativeInputMovement = horizontalInput * right * deltaTime;
         //we combine directions for horizontal and vertical and translate the object
         objectToTranslate.Translate(verticalRelativeInputMovement + horizontalRelativeInputMovement, Space.World);
+    }
+
+    public static void ClampTranslationInsideCameraBounds(this Transform objectToClamp, Camera camera)
+    {
+        if (objectToClamp == null || camera == null) return; //we don't do anything if the object is null
+        // TODO: move this calculations inside its own class inheriting from Unity Camera and adding those properties
+        // Those should only be recalculated when the player changes resolution (we can make a callback OnResolutionChange to be
+        // triggered when the player changes resolution from pause menu)
+        // TODO: calculations breaks when the player moves the character to the sides or up/down
+        //we calculate the boundaries of the camera view
+        float cameraWidth = Screen.width / camera.fieldOfView / 2.0f;
+        float cameraHeigth = cameraWidth / camera.aspect;
+        //we have to apply an offset to align to the player's view
+        float offset = cameraHeigth / 2.0f;
+        //we move the object to the correct local position clamping it's value to be inside of the camera view
+        objectToClamp.localPosition = new Vector3
+        {
+            x = Mathf.Clamp(objectToClamp.localPosition.x, -cameraWidth, cameraWidth),
+            y = Mathf.Clamp(objectToClamp.localPosition.y, -cameraHeigth + offset, cameraHeigth + offset),
+            z = objectToClamp.localPosition.z
+        };
     }
 }

--- a/Assets/Scripts/Gameplay/Managers/PlayerWeaponsManager.cs
+++ b/Assets/Scripts/Gameplay/Managers/PlayerWeaponsManager.cs
@@ -158,7 +158,7 @@ namespace Unity.FPS.Gameplay
             //we translate the player object according to the player input
             m_PlayerCharacterController.transform.SmoothTranslate(verticalInput, horizontalInput, cameraUp, cameraRight, Time.deltaTime);
 
-            //after translate we clamp the localposition
+            //after translate we clamp the local position
             //todo:
 
             //we make the camera to look at the dolly cart point
@@ -174,8 +174,8 @@ namespace Unity.FPS.Gameplay
             //we translate the target aiming object according to the player input
             TargetAimingPosition.SmoothTranslate(verticalInput, horizontalInput, cameraUp, cameraRight, Time.deltaTime);
 
-            //after translate we clamp the localposition
-            //todo:
+            //after translate we clamp the local position
+            TargetAimingPosition.ClampTranslationInsideCameraBounds(m_PlayerCharacterController.PlayerCamera);
 
             //we make the parent root object (which holds the weapon) to look at the target point
             ParentAimingObject.SmoothLookAt(TargetAimingPosition, cameraUp, smoothAimingAtRotationSpeed);


### PR DESCRIPTION
We calculate the camera view boundaries and we clamp the values to be inside of that limits so the player cannot aim outside camera view Changed Player prefab so now the Crosshair's Canvas is drawn on the Player Camera

resolves #22 