### PR TITLE
BFE-32 Make the player move inside certain configurable boundaries

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -436,7 +436,7 @@ Camera:
     height: 1
   near clip plane: 0.1
   far clip plane: 10
-  field of view: 60
+  field of view: 85
   orthographic: 0
   orthographic size: 5
   m_Depth: 0
@@ -1033,7 +1033,7 @@ Camera:
     height: 1
   near clip plane: 0.1
   far clip plane: 300
-  field of view: 60
+  field of view: 85
   orthographic: 0
   orthographic size: 5
   m_Depth: -1

--- a/Assets/Scripts/Common/ExtensionMethods/TransformExtensionMethods.cs
+++ b/Assets/Scripts/Common/ExtensionMethods/TransformExtensionMethods.cs
@@ -39,11 +39,35 @@ public static class TransformExtensionMethods
         //we have to apply an offset to align to the player's view
         float offset = cameraHeigth / 2.0f;
         //we move the object to the correct local position clamping it's value to be inside of the camera view
-        objectToClamp.localPosition = new Vector3
+        Vector3 localPosition = new Vector3
         {
             x = Mathf.Clamp(objectToClamp.localPosition.x, -cameraWidth, cameraWidth),
             y = Mathf.Clamp(objectToClamp.localPosition.y, -cameraHeigth + offset, cameraHeigth + offset),
             z = objectToClamp.localPosition.z
         };
+        //we assign the local position
+        objectToClamp.localPosition = localPosition;
+    }
+
+    public static void ClampTranslationInsideBounds(this Transform objectToClamp, Vector2 limits)
+    {
+        if (objectToClamp == null) return; //we don't do anything if the object is null
+        //we clamp the local position inside given limit values
+        objectToClamp.ClampTranslationInsideBounds(limits.x, limits.y);
+    }
+
+    public static void ClampTranslationInsideBounds(this Transform objectToClamp, float limitX, float limitY)
+    {
+        if (objectToClamp == null) return; //we don't do anything if the object is null
+
+        //we clamp the local position inside given limit values
+        Vector3 localPosition = new Vector3
+        {
+            x = Mathf.Clamp(objectToClamp.localPosition.x, -limitX, limitX),
+            y = Mathf.Clamp(objectToClamp.localPosition.y, -limitY, limitY),
+            z = objectToClamp.localPosition.z
+        };
+        //we assign the local position
+        objectToClamp.localPosition = localPosition;
     }
 }


### PR DESCRIPTION
Set the player and weapon cameras of player prefab to a field of view of 85 as it is set by the player scripts Added ClampTranslationInsideBounds method to manage clamping a local position to be inside certain limits We now clamp the the local position of the player character inside certain boundaries

Resolves #32