### PR TITLE
BFE-67 - Fix the movement and aiming going outside boundaries

### DIFF
--- a/Assets/Prefabs/Player.prefab
+++ b/Assets/Prefabs/Player.prefab
@@ -703,8 +703,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   HorizontalLookSensitivity: 12
   VerticalLookSensitivity: 10
-  HorizontalMovementSpeed: 6
-  VerticalMovementSpeed: 5
+  HorizontalMovementSpeed: 7
+  VerticalMovementSpeed: 6
   WebglLookSensitivityMultiplier: 0.25
   TriggerAxisThreshold: 0.4
   InvertYAxis: 0

--- a/Assets/Scripts/Common/ExtensionMethods/CameraExtensionMethods.cs
+++ b/Assets/Scripts/Common/ExtensionMethods/CameraExtensionMethods.cs
@@ -1,0 +1,27 @@
+﻿using UnityEngine;
+
+public static class CameraExtensionMethods
+{
+    public static Vector3 CameraBottomLeftLocalSpace(this Camera camera, float objectPositionZ)
+    {
+        if (camera == null) return Vector3.zero;  //we return zero if the object is null
+        //we calculate the screen bounds from screen to world space and we convert the screen bounds from world space to local space
+        return camera.CameraPositionOnLocalSpace(new Vector3(0, 0, objectPositionZ));
+    }
+
+    public static Vector3 CameraTopRightLocalSpace(this Camera camera, float objectPositionZ)
+    {
+        if (camera == null) return Vector3.zero;  //we return zero if the object is null
+        //we calculate the screen bounds from screen to world space and we convert the screen bounds from world space to local space
+        return camera.CameraPositionOnLocalSpace(new Vector3(Screen.width, Screen.height, objectPositionZ));
+    }
+
+    public static Vector3 CameraPositionOnLocalSpace(this Camera camera, Vector3 position)
+    {
+        if (camera == null) return Vector3.zero;  //we return zero if the object is null
+        //we calculate the position from screen to world space
+        Vector3 worldPoint = camera.ScreenToWorldPoint(position);
+        //we convert the position from world space to local space which we want to move
+        return camera.transform.InverseTransformPoint(worldPoint);
+    }
+}

--- a/Assets/Scripts/Common/ExtensionMethods/CameraExtensionMethods.cs.meta
+++ b/Assets/Scripts/Common/ExtensionMethods/CameraExtensionMethods.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 995e96e14ac596b4f85839c0a6c6bdb0
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Common/ExtensionMethods/RendererExtensionMethods.cs
+++ b/Assets/Scripts/Common/ExtensionMethods/RendererExtensionMethods.cs
@@ -1,0 +1,13 @@
+﻿using UnityEngine;
+
+public static class RendererExtensionMethods
+{
+    public static Vector3 GetRendererBoundsSize(this Renderer renderer)
+    {
+        if(renderer == null) return Vector3.zero;  //we return zero if the object is null
+        //we calculate the bounds
+        Bounds objectToClampRendererBounds = renderer.bounds;
+        //we return the size
+        return objectToClampRendererBounds.size;
+    }
+}

--- a/Assets/Scripts/Common/ExtensionMethods/RendererExtensionMethods.cs.meta
+++ b/Assets/Scripts/Common/ExtensionMethods/RendererExtensionMethods.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 267984af1a25429488bc81087d1293f2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Gameplay/Managers/PlayerWeaponsManager.cs
+++ b/Assets/Scripts/Gameplay/Managers/PlayerWeaponsManager.cs
@@ -113,7 +113,7 @@ namespace Unity.FPS.Gameplay
 
             // TODO: this should be taken from each dolly cart point which will tell us the limits from the
             // current part of the path (to avoid going through building on tunnels, for instance)
-            PlayerCharacterTranslationLimits = new Vector2(2, 1);
+            PlayerCharacterTranslationLimits = new Vector2(3, 2);
         }
 
         void Start()
@@ -167,7 +167,8 @@ namespace Unity.FPS.Gameplay
             m_PlayerCharacterController.transform.ClampTranslationInsideBounds(PlayerCharacterTranslationLimits);
 
             //we make the camera to look at the dolly cart point
-            m_PlayerCharacterController.PlayerCamera.transform.SmoothLookAt(m_DollyCart.transform, cameraUp, smoothLookAtRotationSpeed);
+            //TODO: here we lose the correct aiming. FIX and re add this functionality
+            //m_PlayerCharacterController.PlayerCamera.transform.SmoothLookAt(m_DollyCart.transform, cameraUp, smoothLookAtRotationSpeed);
         }
 
         private void HandleAiming()


### PR DESCRIPTION
Refactored to take the camera bounds correctly to set the aim clamping Refactored clamping to be split into different classes like CameraExtensionMethods and RendererExtensionMethods We commented the look at functionality when the player character moves because that breaks the limits of aiming Incremented movement velocity on the player prefab

Resolves #67