### PR TITLE
[BFE-25] - Make the crosshair able to change its sprite

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -779,6 +779,7 @@ MonoBehaviour:
     m_Bits: 1024
   smoothLookAtRotationSpeed: 1
   smoothAimingAtRotationSpeed: 10
+  crosshairReference: {fileID: 1122610430159900552}
   m_InputHandler: {fileID: 6145509692674227223}
   m_PlayerCharacterController: {fileID: 814417836257332542}
 --- !u!143 &3122855503829242450

--- a/Assets/Scripts/Gameplay/Managers/PlayerWeaponsManager.cs
+++ b/Assets/Scripts/Gameplay/Managers/PlayerWeaponsManager.cs
@@ -4,6 +4,7 @@ using System.Collections.Generic;
 using Unity.FPS.Game;
 using UnityEngine;
 using UnityEngine.Events;
+using UnityEngine.UI;
 
 namespace Unity.FPS.Gameplay
 {
@@ -81,6 +82,9 @@ namespace Unity.FPS.Gameplay
         [Tooltip("Velocity at which we want to rotate the active weapon to aim at the crosshair direction")]
         public float smoothAimingAtRotationSpeed = 10f;
 
+        [Tooltip("Crosshair Canvas element reference")]
+        public Image crosshairReference;
+
         public bool IsPointingAtEnemy { get; private set; }
         public int ActiveWeaponIndex { get; private set; }
         public Vector2 PlayerCharacterTranslationLimits { get; private set; }
@@ -110,6 +114,8 @@ namespace Unity.FPS.Gameplay
         {
             m_DollyCart = GameObject.FindObjectOfType<CinemachineDollyCart>();
             DebugUtility.HandleErrorIfNullFindObject<CinemachineDollyCart, PlayerWeaponsManager>(m_DollyCart, this);
+
+            DebugUtility.HandleErrorIfNullFindObject<Image, PlayerWeaponsManager>(crosshairReference, this);
 
             // TODO: this should be taken from each dolly cart point which will tell us the limits from the
             // current part of the path (to avoid going through building on tunnels, for instance)
@@ -341,6 +347,14 @@ namespace Unity.FPS.Gameplay
             return null;
         }
 
+        private void UpdateToCurrentWeaponCrosshair()
+        {
+            // we get the active weapon
+            WeaponController newWeapon = GetActiveWeapon();
+            // we change the sprite
+            crosshairReference.sprite = newWeapon.CrosshairDataDefault.CrosshairSprite;
+        }
+
         // Updates weapon position and camera FoV for the aiming transition
         void UpdateWeaponAiming()
         {
@@ -444,6 +458,8 @@ namespace Unity.FPS.Gameplay
                 else if (m_WeaponSwitchState == WeaponSwitchState.PutUpNew)
                 {
                     m_WeaponSwitchState = WeaponSwitchState.Up;
+                    // we update the crosshair when we finished the weapon up animation
+                    UpdateToCurrentWeaponCrosshair();
                 }
             }
 


### PR DESCRIPTION
Added into PlayerWeaponManager a reference to the UI Crosshair so we are able to change its sprite everytime we change the active weapon Resolves #25