### PR TITLE
[BFE-88] - Make the two types of enemies/shots using scriptable objects

### DIFF
--- a/Assets/Configs.meta
+++ b/Assets/Configs.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: bb80a80544c38894cb159abe093aaa2e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Configs/Enemy.meta
+++ b/Assets/Configs/Enemy.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 4204dfbaa2b8f4247afcb080fc7dc5bd
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Configs/Enemy/EnemyBlue.asset
+++ b/Assets/Configs/Enemy/EnemyBlue.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e2ceb96c7d60e94b83e02471c22f286, type: 3}
+  m_Name: EnemyBlue
+  m_EditorClassIdentifier: 
+  type: 1

--- a/Assets/Configs/Enemy/EnemyBlue.asset.meta
+++ b/Assets/Configs/Enemy/EnemyBlue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0283c13bc49453c489b8355a37b931ab
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Configs/Enemy/EnemyGreen.asset
+++ b/Assets/Configs/Enemy/EnemyGreen.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 2e2ceb96c7d60e94b83e02471c22f286, type: 3}
+  m_Name: EnemyGreen
+  m_EditorClassIdentifier: 
+  type: 0

--- a/Assets/Configs/Enemy/EnemyGreen.asset.meta
+++ b/Assets/Configs/Enemy/EnemyGreen.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 01975a801e184f34a95da8342808d0a5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Configs/Shot.meta
+++ b/Assets/Configs/Shot.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 6660721e7c71bc849b9f47b40e6de13e
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Configs/Shot/ShotBlue.asset
+++ b/Assets/Configs/Shot/ShotBlue.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f059d3d9b2606f64c8fb5b8e6b7ec20f, type: 3}
+  m_Name: ShotBlue
+  m_EditorClassIdentifier: 
+  Type: 1

--- a/Assets/Configs/Shot/ShotBlue.asset.meta
+++ b/Assets/Configs/Shot/ShotBlue.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5111d486a6105f54387395ca5cfc7a87
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Configs/Shot/ShotGreen.asset
+++ b/Assets/Configs/Shot/ShotGreen.asset
@@ -1,0 +1,15 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!114 &11400000
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f059d3d9b2606f64c8fb5b8e6b7ec20f, type: 3}
+  m_Name: ShotGreen
+  m_EditorClassIdentifier: 
+  Type: 0

--- a/Assets/Configs/Shot/ShotGreen.asset.meta
+++ b/Assets/Configs/Shot/ShotGreen.asset.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: aca828b6b8b88ed46afca7340f951649
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 11400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Enemies/Enemy_HoverBot.prefab
+++ b/Assets/Prefabs/Enemies/Enemy_HoverBot.prefab
@@ -108,14 +108,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SelfDestructYHeight: -20
+  EnemyConfig: {fileID: 11400000, guid: 01975a801e184f34a95da8342808d0a5, type: 2}
   PathReachingRadius: 2
   OrientationSpeed: 10
   DeathDuration: 0
   SwapToNextWeapon: 0
   DelayAfterWeaponSwap: 0
   EyeColorMaterial: {fileID: 2100000, guid: e6fdfd4e017234d43ac116abee8fa90a, type: 2}
-  DefaultEyeColor: {r: 23.849056, g: 7.292185, b: 0, a: 1}
-  AttackEyeColor: {r: 32, g: 1.4610044, b: 0, a: 1}
+  DefaultEyeColor: {r: 0.44705886, g: 1, b: 0.44705886, a: 1}
+  AttackEyeColor: {r: 0.44705886, g: 1, b: 0.44705886, a: 1}
   BodyMaterial: {fileID: 2100000, guid: c3dc5a90c49c99142999f85d6b419d80, type: 2}
   OnHitBodyGradient:
     serializedVersion: 2
@@ -759,6 +760,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   WeaponName: 
+  ShotConfig: {fileID: 0}
   WeaponIcon: {fileID: 0}
   CrosshairDataDefault:
     CrosshairSprite: {fileID: 0}

--- a/Assets/Prefabs/Enemies/Enemy_Turret.prefab
+++ b/Assets/Prefabs/Enemies/Enemy_Turret.prefab
@@ -243,14 +243,15 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   SelfDestructYHeight: -20
+  EnemyConfig: {fileID: 11400000, guid: 0283c13bc49453c489b8355a37b931ab, type: 2}
   PathReachingRadius: 0
   OrientationSpeed: 10
   DeathDuration: 0
   SwapToNextWeapon: 0
   DelayAfterWeaponSwap: 0
   EyeColorMaterial: {fileID: 2100000, guid: 778fbfe9a7e4a96418b9312dbfc4d67c, type: 2}
-  DefaultEyeColor: {r: 23.849056, g: 7.292185, b: 0, a: 1}
-  AttackEyeColor: {r: 32, g: 1.4610044, b: 0, a: 1}
+  DefaultEyeColor: {r: 0, g: 0.64177275, b: 1, a: 1}
+  AttackEyeColor: {r: 0, g: 0.64177275, b: 1, a: 1}
   BodyMaterial: {fileID: 2100000, guid: bc52f7878b77b454787353158253aa1a, type: 2}
   OnHitBodyGradient:
     serializedVersion: 2
@@ -685,6 +686,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   WeaponName: mg
+  ShotConfig: {fileID: 0}
   WeaponIcon: {fileID: 0}
   CrosshairDataDefault:
     CrosshairSprite: {fileID: 0}

--- a/Assets/Prefabs/Weapons/Weapon_Blaster.prefab
+++ b/Assets/Prefabs/Weapons/Weapon_Blaster.prefab
@@ -178,15 +178,16 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   WeaponName: Blaster
+  ShotConfig: {fileID: 11400000, guid: aca828b6b8b88ed46afca7340f951649, type: 2}
   WeaponIcon: {fileID: 21300000, guid: 3c187e19c32c13542ba8a0c1a3a88ece, type: 3}
   CrosshairDataDefault:
     CrosshairSprite: {fileID: 21300000, guid: e881aa18189b12f4e915fc5b14ddc421, type: 3}
     CrosshairSize: 55
-    CrosshairColor: {r: 1, g: 1, b: 1, a: 0.38431373}
+    CrosshairColor: {r: 0.44705886, g: 1, b: 0.44705886, a: 1}
   CrosshairDataTargetInSight:
     CrosshairSprite: {fileID: 21300000, guid: e881aa18189b12f4e915fc5b14ddc421, type: 3}
     CrosshairSize: 40
-    CrosshairColor: {r: 1, g: 0, b: 0, a: 1}
+    CrosshairColor: {r: 0.44705886, g: 1, b: 0.44705886, a: 1}
   WeaponRoot: {fileID: 1505447205160222267}
   WeaponMuzzle: {fileID: 8334323006752503713}
   ShootType: 1

--- a/Assets/Prefabs/Weapons/Weapon_Shotgun.prefab
+++ b/Assets/Prefabs/Weapons/Weapon_Shotgun.prefab
@@ -146,11 +146,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   WeaponName: Shotgun
+  ShotConfig: {fileID: 11400000, guid: 5111d486a6105f54387395ca5cfc7a87, type: 2}
   WeaponIcon: {fileID: 21300000, guid: 8cbb10368086f014a8b7fc8932e7f436, type: 3}
   CrosshairDataDefault:
     CrosshairSprite: {fileID: 21300000, guid: 2962952d6e5ae7342a298d45a3945069, type: 3}
     CrosshairSize: 40
-    CrosshairColor: {r: 0.4292453, g: 0.8855148, b: 1, a: 0.41960785}
+    CrosshairColor: {r: 0, g: 0.64177275, b: 1, a: 1}
   CrosshairDataTargetInSight:
     CrosshairSprite: {fileID: 21300000, guid: 2962952d6e5ae7342a298d45a3945069, type: 3}
     CrosshairSize: 30

--- a/Assets/Scripts/AI/EnemyController.cs
+++ b/Assets/Scripts/AI/EnemyController.cs
@@ -25,6 +25,9 @@ namespace Unity.FPS.AI
         [Tooltip("The Y height at which the enemy will be automatically killed (if it falls off of the level)")]
         public float SelfDestructYHeight = -20f;
 
+        [Tooltip("Enemy Scriptable Object Config)")]
+        public EnemyConfig EnemyConfig;
+
         [Tooltip("The distance at which the enemy considers that it has reached its current path destination point")]
         public float PathReachingRadius = 2f;
 

--- a/Assets/Scripts/AI/fps.AI.asmdef
+++ b/Assets/Scripts/AI/fps.AI.asmdef
@@ -1,7 +1,9 @@
 {
     "name": "fps.AI",
+    "rootNamespace": "",
     "references": [
-        "GUID:9c5543eabb73a6249ac07b2c065ee8b4"
+        "GUID:9c5543eabb73a6249ac07b2c065ee8b4",
+        "GUID:3e47fdac996f04c4ba24d4250cc3bcdb"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Scripts/Config.meta
+++ b/Assets/Scripts/Config.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: dc3c84d5b9a9de046b653d02d9bc3c4f
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Config/EnemyConfig.cs
+++ b/Assets/Scripts/Config/EnemyConfig.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "New Enemy Type", menuName = "Config/Enemy type")]
+public class EnemyConfig : ScriptableObject
+{
+    public TypeEnum.Option type;
+}

--- a/Assets/Scripts/Config/EnemyConfig.cs.meta
+++ b/Assets/Scripts/Config/EnemyConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 2e2ceb96c7d60e94b83e02471c22f286
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Config/ShotTypeConfig.cs
+++ b/Assets/Scripts/Config/ShotTypeConfig.cs
@@ -1,0 +1,7 @@
+using UnityEngine;
+
+[CreateAssetMenu(fileName = "New Shot Type", menuName = "Config/Shot Type")]
+public class ShotTypeConfig : ScriptableObject
+{
+    public TypeEnum.Option Type;
+}

--- a/Assets/Scripts/Config/ShotTypeConfig.cs.meta
+++ b/Assets/Scripts/Config/ShotTypeConfig.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f059d3d9b2606f64c8fb5b8e6b7ec20f
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Config/TypeEnum.cs
+++ b/Assets/Scripts/Config/TypeEnum.cs
@@ -1,0 +1,8 @@
+﻿public class TypeEnum
+{
+    public enum Option
+    {
+        Green,
+        Blue,
+    }
+}

--- a/Assets/Scripts/Config/TypeEnum.cs.meta
+++ b/Assets/Scripts/Config/TypeEnum.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 8fed903067e161c4a89366cc0d94a41e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Config/fps.Config.asmdef
+++ b/Assets/Scripts/Config/fps.Config.asmdef
@@ -1,0 +1,3 @@
+{
+	"name": "fps.Config"
+}

--- a/Assets/Scripts/Config/fps.Config.asmdef.meta
+++ b/Assets/Scripts/Config/fps.Config.asmdef.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: 3e47fdac996f04c4ba24d4250cc3bcdb
+AssemblyDefinitionImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Game/Shared/WeaponController.cs
+++ b/Assets/Scripts/Game/Shared/WeaponController.cs
@@ -31,6 +31,9 @@ namespace Unity.FPS.Game
         [Header("Information")] [Tooltip("The name that will be displayed in the UI for this weapon")]
         public string WeaponName;
 
+        [Tooltip("Shot Scriptable Object Config)")]
+        public ShotTypeConfig ShotConfig;
+
         [Tooltip("The image that will be displayed in the UI for this weapon")]
         public Sprite WeaponIcon;
 
@@ -47,7 +50,7 @@ namespace Unity.FPS.Game
         [Tooltip("Tip of the weapon, where the projectiles are shot")]
         public Transform WeaponMuzzle;
 
-        [Header("Shoot Parameters")] [Tooltip("The type of weapon wil affect how it shoots")]
+        [Header("Shoot Parameters")] [Tooltip("The type of weapon will affect how it shoots")]
         public WeaponShootType ShootType;
 
         [Tooltip("The projectile prefab")] public ProjectileBase ProjectilePrefab;

--- a/Assets/Scripts/Game/fps.Game.asmdef
+++ b/Assets/Scripts/Game/fps.Game.asmdef
@@ -4,7 +4,8 @@
     "references": [
         "GUID:1826c0224c0d048b88112c79bbb0cd85",
         "GUID:4307f53044263cf4b835bd812fc161a4",
-        "GUID:33759803a11f4d538227861a78aba30b"
+        "GUID:33759803a11f4d538227861a78aba30b",
+        "GUID:3e47fdac996f04c4ba24d4250cc3bcdb"
     ],
     "includePlatforms": [],
     "excludePlatforms": [],

--- a/Assets/Scripts/Gameplay/Managers/PlayerWeaponsManager.cs
+++ b/Assets/Scripts/Gameplay/Managers/PlayerWeaponsManager.cs
@@ -367,6 +367,8 @@ namespace Unity.FPS.Gameplay
             WeaponController newWeapon = GetActiveWeapon();
             // we change the sprite
             crosshairReference.sprite = newWeapon.CrosshairDataDefault.CrosshairSprite;
+            // we change the color of the sprite
+            crosshairReference.color = newWeapon.CrosshairDataDefault.CrosshairColor;
         }
 
         // Updates weapon position and camera FoV for the aiming transition


### PR DESCRIPTION
Created a new assembly which contains the new Scriptable Objects configs for shot and enemy types Created config assets for blue and green for enemy and shots Added EnemyConfig parameter to HoverBot and Turret enemies Added ShotTypeConfig parameter to Blaster and Shotgun weapons Added the ability to change the crosshair color according to weapon

Resolves #88