### PR TITLE
[BFE-44] - Change player collider to make difficult to be hit

### DIFF
--- a/Assets/Prefabs/Player/Player.prefab
+++ b/Assets/Prefabs/Player/Player.prefab
@@ -646,7 +646,6 @@ MonoBehaviour:
     m_Bits: 1024
   smoothLookAtRotationSpeed: 1
   smoothAimingAtRotationSpeed: 10
-  OnPowerupActivated: {fileID: 0}
   m_InputHandler: {fileID: 6145509692674227223}
   m_PlayerCharacterController: {fileID: 814417836257332542}
 --- !u!143 &3122855503829242450
@@ -668,13 +667,13 @@ CharacterController:
   m_ProvidesContacts: 0
   m_Enabled: 1
   serializedVersion: 3
-  m_Height: 1.8
-  m_Radius: 0.35
+  m_Height: 0.5
+  m_Radius: 0.2
   m_SlopeLimit: 45
   m_StepOffset: 0.3
   m_SkinWidth: 0.001
   m_MinMoveDistance: 0
-  m_Center: {x: 0, y: 1, z: 0}
+  m_Center: {x: 0, y: 1.5, z: 0}
 --- !u!114 &6268538116984687401
 MonoBehaviour:
   m_ObjectHideFlags: 0


### PR DESCRIPTION
Decrease size of the collider for the player and moved up to be centered with the camera

Resolves #44